### PR TITLE
feat: add opt-in future compatibility ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ includes:
 
 or you use PHPStan Extension Installer
 
+### Future compatibility (opt-in)
+
+To validate an extension against announced Shopware BC changes as well as the installed
+version, include the separate ruleset:
+
+```neon
+includes:
+    - vendor/shopwarelabs/phpstan-shopware/future-compatibility.neon
+```
+
+It reports calls and extensions incompatible with the next-major declaration announced by
+Shopware's BC-change attributes. This ruleset is intentionally separate from `rules.neon`:
+adopting it means choosing to prepare for the next major while remaining compatible with the
+current one.
+
 ## Features
 
 - Custom rules for Shopware 6.5 specific patterns

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "classmap": [
       "tests/Rule/fixtures",
-      "tests/Rule/BestPractise/fixtures"
+      "tests/Rule/BestPractise/fixtures",
+      "tests/Type/fixtures"
     ]
   },
   "config": {

--- a/future-compatibility.neon
+++ b/future-compatibility.neon
@@ -1,0 +1,17 @@
+# Opt-in analysis for extension code that must run on the current and the next Shopware major.
+#
+# includes:
+#     - vendor/shopwarelabs/phpstan-shopware/future-compatibility.neon
+
+services:
+    -
+        class: Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver
+    -
+        class: Shopware\PhpStan\Rule\FutureCompatibility\FutureCallSiteRule
+        tags: [phpstan.rules.rule]
+    -
+        class: Shopware\PhpStan\Rule\FutureCompatibility\FutureExtensionRule
+        tags: [phpstan.rules.rule]
+    -
+        class: Shopware\PhpStan\Type\FutureReturnTypeExtension
+        tags: [phpstan.broker.expressionTypeResolverExtension]

--- a/future-compatibility.neon
+++ b/future-compatibility.neon
@@ -10,6 +10,9 @@ services:
         class: Shopware\PhpStan\Rule\FutureCompatibility\FutureCallSiteRule
         tags: [phpstan.rules.rule]
     -
+        class: Shopware\PhpStan\Rule\FutureCompatibility\FuturePropertyCompatibilityRule
+        tags: [phpstan.rules.rule]
+    -
         class: Shopware\PhpStan\Rule\FutureCompatibility\FutureExtensionRule
         tags: [phpstan.rules.rule]
     -

--- a/future-compatibility.neon
+++ b/future-compatibility.neon
@@ -18,3 +18,6 @@ services:
     -
         class: Shopware\PhpStan\Type\FutureReturnTypeExtension
         tags: [phpstan.broker.expressionTypeResolverExtension]
+    -
+        class: Shopware\PhpStan\Type\FuturePropertyTypeExtension
+        tags: [phpstan.broker.expressionTypeResolverExtension]

--- a/src/Rule/ForbidInsecureSymfonyCookieRule.php
+++ b/src/Rule/ForbidInsecureSymfonyCookieRule.php
@@ -7,13 +7,17 @@ namespace Shopware\PhpStan\Rule;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -21,7 +25,7 @@ use PHPStan\Type\ObjectType;
 use Symfony\Component\HttpFoundation\Cookie;
 
 /**
- * @implements Rule<Expr>
+ * @implements Rule<InClassMethodNode>
  */
 class ForbidInsecureSymfonyCookieRule implements Rule
 {
@@ -31,7 +35,7 @@ class ForbidInsecureSymfonyCookieRule implements Rule
 
     public function getNodeType(): string
     {
-        return Expr::class;
+        return InClassMethodNode::class;
     }
 
     /**
@@ -39,19 +43,32 @@ class ForbidInsecureSymfonyCookieRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($node instanceof New_) {
-            return $this->processNew($node, $scope);
+        $finder = new NodeFinder();
+        $methodCalls = $finder->findInstanceOf($node->getOriginalNode(), MethodCall::class);
+        $secureFluentCookies = [];
+
+        foreach ($methodCalls as $methodCall) {
+            if (($methodCall->var instanceof New_ || $methodCall->var instanceof StaticCall) && $this->isEnabledWithSecureCall($methodCall)) {
+                $secureFluentCookies[spl_object_id($methodCall->var)] = true;
+            }
         }
 
-        if ($node instanceof StaticCall) {
-            return $this->processStaticCall($node, $scope);
+        $errors = [];
+        foreach ($finder->findInstanceOf($node->getOriginalNode(), Expr::class) as $expression) {
+            if ($expression instanceof New_ && !isset($secureFluentCookies[spl_object_id($expression)])) {
+                $errors = [...$errors, ...$this->processNew($expression, $scope)];
+            }
+
+            if ($expression instanceof StaticCall && !isset($secureFluentCookies[spl_object_id($expression)])) {
+                $errors = [...$errors, ...$this->processStaticCall($expression, $scope)];
+            }
+
+            if ($expression instanceof MethodCall) {
+                $errors = [...$errors, ...$this->processMethodCall($expression, $scope, $node)];
+            }
         }
 
-        if ($node instanceof MethodCall) {
-            return $this->processMethodCall($node, $scope);
-        }
-
-        return [];
+        return $errors;
     }
 
     /**
@@ -97,7 +114,7 @@ class ForbidInsecureSymfonyCookieRule implements Rule
     /**
      * @return list<IdentifierRuleError>
      */
-    private function processMethodCall(MethodCall $node, Scope $scope): array
+    private function processMethodCall(MethodCall $node, Scope $scope, InClassMethodNode $method): array
     {
         if (!$node->name instanceof Identifier) {
             return [];
@@ -107,9 +124,7 @@ class ForbidInsecureSymfonyCookieRule implements Rule
             return [];
         }
 
-        $calledOnType = $scope->getType($node->var);
-        $cookieType = new ObjectType(self::SYMFONY_COOKIE_CLASS);
-        if (!$cookieType->isSuperTypeOf($calledOnType)->yes()) {
+        if (!$this->isSymfonyCookieMethodCall($node, $scope, $method)) {
             return [];
         }
 
@@ -139,23 +154,13 @@ class ForbidInsecureSymfonyCookieRule implements Rule
      */
     private function checkSecureParam(array $args, Node $node): array
     {
-        if ($this->hasEnabledSecureParam($args)) {
+        $secureArg = $this->findSecureArg($args);
+
+        if ($secureArg !== null && $secureArg->value instanceof ConstFetch && $secureArg->value->name->toLowerString() === 'true') {
             return [];
         }
 
         return $this->buildError($node);
-    }
-
-    /**
-     * @param array<Arg> $args
-     */
-    private function hasEnabledSecureParam(array $args): bool
-    {
-        $secureArg = $this->findSecureArg($args);
-
-        return $secureArg !== null
-            && $secureArg->value instanceof ConstFetch
-            && $secureArg->value->name->toLowerString() === 'true';
     }
 
     /**
@@ -186,6 +191,61 @@ class ForbidInsecureSymfonyCookieRule implements Rule
         }
 
         return $args[self::SECURE_PARAM_INDEX];
+    }
+
+    /**
+     * @param array<Arg> $args
+     */
+    private function hasEnabledSecureParam(array $args): bool
+    {
+        $secureArg = $this->findSecureArg($args);
+
+        return $secureArg !== null
+            && $secureArg->value instanceof ConstFetch
+            && $secureArg->value->name->toLowerString() === 'true';
+    }
+
+    private function isEnabledWithSecureCall(MethodCall $node): bool
+    {
+        if (!$node->name instanceof Identifier || $node->name->name !== 'withSecure') {
+            return false;
+        }
+
+        $args = $node->getArgs();
+        if ($args === []) {
+            return true;
+        }
+
+        $secureArg = $args[0];
+
+        return $secureArg->value instanceof ConstFetch && $secureArg->value->name->toLowerString() === 'true';
+    }
+
+    private function isSymfonyCookieMethodCall(MethodCall $node, Scope $scope, InClassMethodNode $method): bool
+    {
+        $cookieType = new ObjectType(self::SYMFONY_COOKIE_CLASS);
+        if ($cookieType->isSuperTypeOf($scope->getType($node->var))->yes()) {
+            return true;
+        }
+
+        if (!$node->var instanceof Variable || !is_string($node->var->name)) {
+            return false;
+        }
+
+        $assignments = (new NodeFinder())->findInstanceOf($method->getOriginalNode(), Assign::class);
+        foreach (array_reverse($assignments) as $assignment) {
+            if ($assignment->getStartFilePos() >= $node->getStartFilePos()
+                || !$assignment->var instanceof Variable
+                || $assignment->var->name !== $node->var->name
+            ) {
+                continue;
+            }
+
+            return ($assignment->expr instanceof New_ || $assignment->expr instanceof StaticCall)
+                && $this->isSymfonyCookie($assignment->expr, $scope);
+        }
+
+        return false;
     }
 
     private function isSymfonyCookie(Expr $node, Scope $scope): bool

--- a/src/Rule/ForbidInsecureSymfonyCookieRule.php
+++ b/src/Rule/ForbidInsecureSymfonyCookieRule.php
@@ -29,8 +29,6 @@ class ForbidInsecureSymfonyCookieRule implements Rule
 
     private const SECURE_PARAM_INDEX = 5;
 
-    private const ATTR_SECURE_CHECKED_BY_WITHSECURE = 'shopware.secureCookieCheckedByWithSecure';
-
     public function getNodeType(): string
     {
         return Expr::class;
@@ -69,12 +67,6 @@ class ForbidInsecureSymfonyCookieRule implements Rule
             return [];
         }
 
-        // If the parent MethodCall (withSecure) already handles the secure flag,
-        // suppress the error for this node.
-        if ($node->getAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE) === true) {
-            return [];
-        }
-
         return $this->checkSecureParam($node->getArgs(), $node);
     }
 
@@ -96,12 +88,6 @@ class ForbidInsecureSymfonyCookieRule implements Rule
         }
 
         if ($node->name->name !== 'create') {
-            return [];
-        }
-
-        // If the parent MethodCall (withSecure) already handles the secure flag,
-        // suppress the error for this node.
-        if ($node->getAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE) === true) {
             return [];
         }
 
@@ -129,9 +115,9 @@ class ForbidInsecureSymfonyCookieRule implements Rule
 
         $args = $node->getArgs();
 
-        // Mark the var so the constructor/create() call does not emit a
-        // duplicate error – the withSecure() call is the authoritative check.
-        $this->markVarAsSecureChecked($node);
+        if (($node->var instanceof New_ || $node->var instanceof StaticCall) && !$this->hasEnabledSecureParam($node->var->getArgs())) {
+            return [];
+        }
 
         // withSecure() with no args defaults to true
         if (!isset($args[0])) {
@@ -153,17 +139,23 @@ class ForbidInsecureSymfonyCookieRule implements Rule
      */
     private function checkSecureParam(array $args, Node $node): array
     {
-        $secureArg = $this->findSecureArg($args);
-
-        if ($secureArg === null) {
-            return $this->buildError($node);
-        }
-
-        if ($secureArg->value instanceof ConstFetch && $secureArg->value->name->toLowerString() === 'true') {
+        if ($this->hasEnabledSecureParam($args)) {
             return [];
         }
 
         return $this->buildError($node);
+    }
+
+    /**
+     * @param array<Arg> $args
+     */
+    private function hasEnabledSecureParam(array $args): bool
+    {
+        $secureArg = $this->findSecureArg($args);
+
+        return $secureArg !== null
+            && $secureArg->value instanceof ConstFetch
+            && $secureArg->value->name->toLowerString() === 'true';
     }
 
     /**
@@ -194,13 +186,6 @@ class ForbidInsecureSymfonyCookieRule implements Rule
         }
 
         return $args[self::SECURE_PARAM_INDEX];
-    }
-
-    private function markVarAsSecureChecked(MethodCall $node): void
-    {
-        if ($node->var instanceof New_ || $node->var instanceof StaticCall) {
-            $node->var->setAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE, true);
-        }
     }
 
     private function isSymfonyCookie(Expr $node, Scope $scope): bool

--- a/src/Rule/FutureCompatibility/AnnouncedTypeResolver.php
+++ b/src/Rule/FutureCompatibility/AnnouncedTypeResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Rule\FutureCompatibility;
+
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/** @internal */
+final readonly class AnnouncedTypeResolver
+{
+    public function __construct(
+        private TypeStringResolver $typeStringResolver,
+        private ReflectionProvider $reflectionProvider,
+    ) {}
+
+    public function resolve(string $typeString, string $declaringClass): ?Type
+    {
+        if (in_array(strtolower($typeString), ['self', 'static', '$this'], true)) {
+            return new ObjectType($declaringClass);
+        }
+
+        try {
+            $type = $this->typeStringResolver->resolve($typeString);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        foreach ($type->getReferencedClasses() as $class) {
+            if (!$this->reflectionProvider->hasClass($class)) {
+                return null;
+            }
+        }
+
+        return $type;
+    }
+}

--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -214,6 +214,6 @@ final class FutureCallSiteRule implements Rule
 
     private function error(string $message): IdentifierRuleError
     {
-        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility')->build();
+        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility.callSite')->build();
     }
 }

--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Rule\FutureCompatibility;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\Adapter\FakeReflectionAttribute;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Reports extension call sites incompatible with a BC-change attribute announced by Core.
+ *
+ * @implements Rule<CallLike>
+ * @internal
+ */
+final class FutureCallSiteRule implements Rule
+{
+    private const ATTRIBUTE_NAMESPACE = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly AnnouncedTypeResolver $typeResolver,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $methodName = $this->methodName($node);
+        if ($methodName === null) {
+            return [];
+        }
+
+        $class = $this->classReflection($node, $scope, $methodName);
+        if ($class === null) {
+            return [];
+        }
+
+        $native = $class->getNativeReflection();
+        $errors = $this->classInternalError($native->getAttributes(), $class);
+        if (!$native->hasMethod($methodName)) {
+            return $errors;
+        }
+
+        $method = $native->getMethod($methodName);
+        $symbol = sprintf('%s::%s()', $class->getDisplayName(), $methodName);
+
+        foreach ($method->getAttributes() as $attribute) {
+            $name = $attribute->getName();
+            $arguments = $attribute->getArguments();
+            $version = $this->stringArgument($arguments, 'version', 0);
+
+            if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
+                $errors[] = $this->error(sprintf('"%s" will become internal in %s. Stop calling it to stay compatible.', $symbol, $version));
+            } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'VisibilityChange') {
+                $visibility = $arguments['newVisibility'] ?? $arguments[1] ?? null;
+                if (!$this->canAccess($visibility, $class, $scope)) {
+                    $errors[] = $this->error(sprintf('"%s" will become %s in %s. This call will break; stop calling it from outside that scope.', $symbol, is_string($visibility) ? $visibility : '?', $version));
+                }
+            } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterRemoval') {
+                $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
+                if (is_string($parameter) && $this->argument($node, $method, $parameter) !== null) {
+                    $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be removed in %s. Stop passing it to stay compatible with both versions.', $parameter, $symbol, $version));
+                }
+            } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterNameChange') {
+                $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
+                foreach ($node->getArgs() as $argument) {
+                    if ($argument->name !== null && $argument->name->toString() === $parameter) {
+                        $newName = $this->stringArgument($arguments, 'newName', 2);
+                        $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be renamed to $%s in %s. A named argument cannot be compatible with both versions; pass it positionally.', $parameter, $symbol, $newName, $version));
+                    }
+                }
+            } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'NewRequiredParameter') {
+                if (!$this->hasUnpack($node) && count($node->getArgs()) <= count($method->getParameters())) {
+                    $parameter = $this->stringArgument($arguments, 'parameterName', 1);
+                    $errors[] = $this->error(sprintf('"%s" will require a new parameter $%s in %s. Pass it positionally now to stay compatible with both versions.', $symbol, $parameter, $version));
+                }
+            } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterDefaultValueChange') {
+                $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
+                if (is_string($parameter) && $this->argument($node, $method, $parameter) === null) {
+                    $errors[] = $this->error(sprintf('The default value of parameter $%s of "%s" will change in %s. Pass the current default explicitly to retain current behavior.', $parameter, $symbol, $version));
+                }
+            } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterTypeNarrowing') {
+                $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
+                $newType = $arguments['newType'] ?? $arguments[2] ?? null;
+                $argument = is_string($parameter) ? $this->argument($node, $method, $parameter) : null;
+                $announced = is_string($newType) ? $this->typeResolver->resolve($newType, $method->getDeclaringClass()->getName()) : null;
+                if ($argument !== null && $announced !== null) {
+                    $actual = $scope->getType($argument->value);
+                    if ($announced->isSuperTypeOf($actual)->no()) {
+                        $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be narrowed to %s in %s, but %s is passed. Pass %s to stay compatible with both versions.', $parameter, $symbol, $newType, $version, $actual->describe(VerbosityLevel::typeOnly()), $newType));
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    private function methodName(CallLike $node): ?string
+    {
+        if (($node instanceof MethodCall || $node instanceof StaticCall) && $node->name instanceof Identifier) {
+            return $node->name->toString();
+        }
+
+        return $node instanceof New_ ? '__construct' : null;
+    }
+
+    private function classReflection(CallLike $node, Scope $scope, string $method): ?ClassReflection
+    {
+        if ($node instanceof MethodCall) {
+            foreach ($scope->getType($node->var)->getObjectClassReflections() as $class) {
+                if ($class->hasNativeMethod($method)) {
+                    return $class;
+                }
+            }
+
+            return null;
+        }
+        if (($node instanceof StaticCall || $node instanceof New_) && $node->class instanceof Name) {
+            $className = $scope->resolveName($node->class);
+
+            return $this->reflectionProvider->hasClass($className) ? $this->reflectionProvider->getClass($className) : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<ReflectionAttribute|FakeReflectionAttribute> $attributes
+     * @return list<IdentifierRuleError>
+     */
+    private function classInternalError(array $attributes, ClassReflection $class): array
+    {
+        foreach ($attributes as $attribute) {
+            if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
+                $arguments = $attribute->getArguments();
+
+                return [$this->error(sprintf('Class "%s" will become internal in %s. Stop using it to stay compatible.', $class->getDisplayName(), $this->stringArgument($arguments, 'version', 0)))];
+            }
+        }
+
+        return [];
+    }
+
+    private function canAccess(mixed $visibility, ClassReflection $class, Scope $scope): bool
+    {
+        $caller = $scope->isInClass() ? $scope->getClassReflection() : null;
+
+        return match ($visibility) {
+            'protected' => $caller !== null && ($caller->getName() === $class->getName() || $caller->isSubclassOfClass($class)),
+            'private' => $caller !== null && $caller->getName() === $class->getName(),
+            default => true,
+        };
+    }
+
+    private function argument(CallLike $node, \ReflectionMethod $method, string $parameter): ?Arg
+    {
+        $position = null;
+        foreach ($method->getParameters() as $candidate) {
+            if ($candidate->getName() === $parameter) {
+                $position = $candidate->getPosition();
+                break;
+            }
+        }
+        foreach ($node->getArgs() as $index => $argument) {
+            if ($argument->unpack) {
+                return null;
+            }
+            if ($argument->name !== null ? $argument->name->toString() === $parameter : $index === $position) {
+                return $argument;
+            }
+        }
+
+        return null;
+    }
+
+    private function hasUnpack(CallLike $node): bool
+    {
+        foreach ($node->getArgs() as $argument) {
+            if ($argument->unpack) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param array<int|string, mixed> $arguments */
+    private function stringArgument(array $arguments, string $name, int $position): string
+    {
+        $value = $arguments[$name] ?? $arguments[$position] ?? '?';
+
+        return is_string($value) ? $value : '?';
+    }
+
+    private function error(string $message): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility')->build();
+    }
+}

--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -32,6 +32,15 @@ final class FutureCallSiteRule implements Rule
 {
     private const ATTRIBUTE_NAMESPACE = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\';
 
+    private const METHOD_BECOMES_INTERNAL = 'shopware.futureIncompatibility.methodBecomesInternal';
+    private const METHOD_VISIBILITY_CHANGE = 'shopware.futureIncompatibility.methodVisibilityChange';
+    private const PARAMETER_REMOVAL = 'shopware.futureIncompatibility.parameterRemoval';
+    private const PARAMETER_NAME_CHANGE = 'shopware.futureIncompatibility.parameterNameChange';
+    private const NEW_REQUIRED_PARAMETER = 'shopware.futureIncompatibility.newRequiredParameter';
+    private const PARAMETER_DEFAULT_VALUE_CHANGE = 'shopware.futureIncompatibility.parameterDefaultValueChange';
+    private const PARAMETER_TYPE_NARROWING = 'shopware.futureIncompatibility.parameterTypeNarrowing';
+    private const CLASS_BECOMES_INTERNAL = 'shopware.futureIncompatibility.classBecomesInternal';
+
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
         private readonly AnnouncedTypeResolver $typeResolver,
@@ -69,34 +78,34 @@ final class FutureCallSiteRule implements Rule
             $version = $this->stringArgument($arguments, 'version', 0);
 
             if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
-                $errors[] = $this->error(sprintf('"%s" will become internal in %s. Stop calling it to stay compatible.', $symbol, $version));
+                $errors[] = $this->error(sprintf('"%s" will become internal in %s. Stop calling it to stay compatible.', $symbol, $version), self::METHOD_BECOMES_INTERNAL);
             } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'VisibilityChange') {
                 $visibility = $arguments['newVisibility'] ?? $arguments[1] ?? null;
                 if (!$this->canAccess($visibility, $class, $scope)) {
-                    $errors[] = $this->error(sprintf('"%s" will become %s in %s. This call will break; stop calling it from outside that scope.', $symbol, is_string($visibility) ? $visibility : '?', $version));
+                    $errors[] = $this->error(sprintf('"%s" will become %s in %s. This call will break; stop calling it from outside that scope.', $symbol, is_string($visibility) ? $visibility : '?', $version), self::METHOD_VISIBILITY_CHANGE);
                 }
             } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterRemoval') {
                 $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
                 if (is_string($parameter) && $this->argument($node, $method, $parameter) !== null) {
-                    $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be removed in %s. Stop passing it to stay compatible with both versions.', $parameter, $symbol, $version));
+                    $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be removed in %s. Stop passing it to stay compatible with both versions.', $parameter, $symbol, $version), self::PARAMETER_REMOVAL);
                 }
             } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterNameChange') {
                 $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
                 foreach ($node->getArgs() as $argument) {
                     if ($argument->name !== null && $argument->name->toString() === $parameter) {
                         $newName = $this->stringArgument($arguments, 'newName', 2);
-                        $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be renamed to $%s in %s. A named argument cannot be compatible with both versions; pass it positionally.', $parameter, $symbol, $newName, $version));
+                        $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be renamed to $%s in %s. A named argument cannot be compatible with both versions; pass it positionally.', $parameter, $symbol, $newName, $version), self::PARAMETER_NAME_CHANGE);
                     }
                 }
             } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'NewRequiredParameter') {
                 if (!$this->hasUnpack($node) && count($node->getArgs()) <= count($method->getParameters())) {
                     $parameter = $this->stringArgument($arguments, 'parameterName', 1);
-                    $errors[] = $this->error(sprintf('"%s" will require a new parameter $%s in %s. Pass it positionally now to stay compatible with both versions.', $symbol, $parameter, $version));
+                    $errors[] = $this->error(sprintf('"%s" will require a new parameter $%s in %s. Pass it positionally now to stay compatible with both versions.', $symbol, $parameter, $version), self::NEW_REQUIRED_PARAMETER);
                 }
             } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterDefaultValueChange') {
                 $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
                 if (is_string($parameter) && $this->argument($node, $method, $parameter) === null) {
-                    $errors[] = $this->error(sprintf('The default value of parameter $%s of "%s" will change in %s. Pass the current default explicitly to retain current behavior.', $parameter, $symbol, $version));
+                    $errors[] = $this->error(sprintf('The default value of parameter $%s of "%s" will change in %s. Pass the current default explicitly to retain current behavior.', $parameter, $symbol, $version), self::PARAMETER_DEFAULT_VALUE_CHANGE);
                 }
             } elseif ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterTypeNarrowing') {
                 $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
@@ -106,7 +115,7 @@ final class FutureCallSiteRule implements Rule
                 if ($argument !== null && $announced !== null) {
                     $actual = $scope->getType($argument->value);
                     if ($announced->isSuperTypeOf($actual)->no()) {
-                        $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be narrowed to %s in %s, but %s is passed. Pass %s to stay compatible with both versions.', $parameter, $symbol, $newType, $version, $actual->describe(VerbosityLevel::typeOnly()), $newType));
+                        $errors[] = $this->error(sprintf('Parameter $%s of "%s" will be narrowed to %s in %s, but %s is passed. Pass %s to stay compatible with both versions.', $parameter, $symbol, $newType, $version, $actual->describe(VerbosityLevel::typeOnly()), $newType), self::PARAMETER_TYPE_NARROWING);
                     }
                 }
             }
@@ -154,7 +163,7 @@ final class FutureCallSiteRule implements Rule
             if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
                 $arguments = $attribute->getArguments();
 
-                return [$this->error(sprintf('Class "%s" will become internal in %s. Stop using it to stay compatible.', $class->getDisplayName(), $this->stringArgument($arguments, 'version', 0)))];
+                return [$this->error(sprintf('Class "%s" will become internal in %s. Stop using it to stay compatible.', $class->getDisplayName(), $this->stringArgument($arguments, 'version', 0)), self::CLASS_BECOMES_INTERNAL)];
             }
         }
 
@@ -212,8 +221,8 @@ final class FutureCallSiteRule implements Rule
         return is_string($value) ? $value : '?';
     }
 
-    private function error(string $message): IdentifierRuleError
+    private function error(string $message, string $identifier): IdentifierRuleError
     {
-        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility.callSite')->build();
+        return RuleErrorBuilder::message($message)->identifier($identifier)->build();
     }
 }

--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -64,7 +64,7 @@ final class FutureCallSiteRule implements Rule
         }
 
         $native = $class->getNativeReflection();
-        $errors = $this->classInternalError($native->getAttributes(), $class);
+        $errors = $this->classInternalError($native->getAttributes(), $class, $scope);
         if (!$native->hasMethod($methodName)) {
             return $errors;
         }
@@ -76,6 +76,10 @@ final class FutureCallSiteRule implements Rule
             $name = $attribute->getName();
             $arguments = $attribute->getArguments();
             $version = $this->stringArgument($arguments, 'version', 0);
+
+            if ($this->isDeprecatedInVersion($scope, $version)) {
+                continue;
+            }
 
             if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
                 $errors[] = $this->error(sprintf('"%s" will become internal in %s. Stop calling it to stay compatible.', $symbol, $version), self::METHOD_BECOMES_INTERNAL);
@@ -157,13 +161,18 @@ final class FutureCallSiteRule implements Rule
      * @param list<ReflectionAttribute|FakeReflectionAttribute> $attributes
      * @return list<IdentifierRuleError>
      */
-    private function classInternalError(array $attributes, ClassReflection $class): array
+    private function classInternalError(array $attributes, ClassReflection $class, Scope $scope): array
     {
         foreach ($attributes as $attribute) {
             if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
                 $arguments = $attribute->getArguments();
 
-                return [$this->error(sprintf('Class "%s" will become internal in %s. Stop using it to stay compatible.', $class->getDisplayName(), $this->stringArgument($arguments, 'version', 0)), self::CLASS_BECOMES_INTERNAL)];
+                $version = $this->stringArgument($arguments, 'version', 0);
+                if ($this->isDeprecatedInVersion($scope, $version)) {
+                    return [];
+                }
+
+                return [$this->error(sprintf('Class "%s" will become internal in %s. Stop using it to stay compatible.', $class->getDisplayName(), $version), self::CLASS_BECOMES_INTERNAL)];
             }
         }
 
@@ -219,6 +228,17 @@ final class FutureCallSiteRule implements Rule
         $value = $arguments[$name] ?? $arguments[$position] ?? '?';
 
         return is_string($value) ? $value : '?';
+    }
+
+    private function isDeprecatedInVersion(Scope $scope, string $version): bool
+    {
+        return $this->hasDeprecationTagForVersion($scope->getClassReflection()?->getDeprecatedDescription(), $version)
+            || $this->hasDeprecationTagForVersion($scope->getFunction()?->getDeprecatedDescription(), $version);
+    }
+
+    private function hasDeprecationTagForVersion(?string $description, string $version): bool
+    {
+        return $description !== null && preg_match(sprintf('/(?:^|\\s)tag:%s(?:\\s|$)/', preg_quote($version, '/')), $description) === 1;
     }
 
     private function error(string $message, string $identifier): IdentifierRuleError

--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -9,7 +9,9 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -23,9 +25,9 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Type\VerbosityLevel;
 
 /**
- * Reports extension call sites incompatible with a BC-change attribute announced by Core.
+ * Reports extension call sites and property accesses incompatible with a BC-change attribute announced by Core.
  *
- * @implements Rule<CallLike>
+ * @implements Rule<Node>
  * @internal
  */
 final class FutureCallSiteRule implements Rule
@@ -34,6 +36,7 @@ final class FutureCallSiteRule implements Rule
 
     private const METHOD_BECOMES_INTERNAL = 'shopware.futureIncompatibility.methodBecomesInternal';
     private const METHOD_VISIBILITY_CHANGE = 'shopware.futureIncompatibility.methodVisibilityChange';
+    private const PROPERTY_VISIBILITY_CHANGE = 'shopware.futureIncompatibility.propertyVisibilityChange';
     private const PARAMETER_REMOVAL = 'shopware.futureIncompatibility.parameterRemoval';
     private const PARAMETER_NAME_CHANGE = 'shopware.futureIncompatibility.parameterNameChange';
     private const NEW_REQUIRED_PARAMETER = 'shopware.futureIncompatibility.newRequiredParameter';
@@ -48,10 +51,23 @@ final class FutureCallSiteRule implements Rule
 
     public function getNodeType(): string
     {
-        return CallLike::class;
+        return Node::class;
     }
 
     public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node instanceof CallLike) {
+            return $this->processCall($node, $scope);
+        }
+
+        if ($node instanceof PropertyFetch || $node instanceof StaticPropertyFetch) {
+            return $this->processPropertyAccess($node, $scope);
+        }
+
+        return [];
+    }
+
+    private function processCall(CallLike $node, Scope $scope): array
     {
         $methodName = $this->methodName($node);
         if ($methodName === null) {
@@ -128,6 +144,48 @@ final class FutureCallSiteRule implements Rule
         return $errors;
     }
 
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function processPropertyAccess(PropertyFetch|StaticPropertyFetch $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $propertyName = $node->name->toString();
+        foreach ($this->propertyClasses($node, $scope) as $class) {
+            $native = $class->getNativeReflection();
+            if (!$native->hasProperty($propertyName)) {
+                continue;
+            }
+
+            $property = $native->getProperty($propertyName);
+            foreach ($property->getAttributes() as $attribute) {
+                if ($attribute->getName() !== self::ATTRIBUTE_NAMESPACE . 'VisibilityChange') {
+                    continue;
+                }
+
+                $arguments = $attribute->getArguments();
+                $version = $this->stringArgument($arguments, 'version', 0);
+                if ($this->isDeprecatedInVersion($scope, $version)) {
+                    continue;
+                }
+
+                $visibility = $arguments['newVisibility'] ?? $arguments[1] ?? null;
+                if ($this->canAccess($visibility, $class, $scope)) {
+                    continue;
+                }
+
+                $symbol = sprintf('%s::$%s', $class->getDisplayName(), $propertyName);
+
+                return [$this->error(sprintf('Property "%s" will become %s in %s. This access will break; stop accessing it from outside that scope.', $symbol, is_string($visibility) ? $visibility : '?', $version), self::PROPERTY_VISIBILITY_CHANGE)];
+            }
+        }
+
+        return [];
+    }
+
     private function methodName(CallLike $node): ?string
     {
         if (($node instanceof MethodCall || $node instanceof StaticCall) && $node->name instanceof Identifier) {
@@ -155,6 +213,24 @@ final class FutureCallSiteRule implements Rule
         }
 
         return null;
+    }
+
+    /**
+     * @return list<ClassReflection>
+     */
+    private function propertyClasses(PropertyFetch|StaticPropertyFetch $node, Scope $scope): array
+    {
+        if ($node instanceof PropertyFetch) {
+            return $scope->getType($node->var)->getObjectClassReflections();
+        }
+
+        if (!$node->class instanceof Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($node->class);
+
+        return $this->reflectionProvider->hasClass($className) ? [$this->reflectionProvider->getClass($className)] : [];
     }
 
     /**

--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -67,6 +67,9 @@ final class FutureCallSiteRule implements Rule
         return [];
     }
 
+    /**
+     * @return list<IdentifierRuleError>
+     */
     private function processCall(CallLike $node, Scope $scope): array
     {
         $methodName = $this->methodName($node);

--- a/src/Rule/FutureCompatibility/FutureExtensionRule.php
+++ b/src/Rule/FutureCompatibility/FutureExtensionRule.php
@@ -46,10 +46,10 @@ final class FutureExtensionRule implements Rule
             foreach ($parent->getNativeReflection()->getAttributes() as $attribute) {
                 $arguments = $attribute->getArguments();
                 $version = $this->stringArgument($arguments, 'version', 0);
-                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesFinal') {
+                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesFinal' && !$this->isDeprecatedInVersion($class, null, $scope, $version)) {
                     $errors[] = $this->error(sprintf('"%s" extends "%s", which will become final in %s. There is no forward-compatible way to keep extending it.', $class->getDisplayName(), $parent->getDisplayName(), $version), self::EXTENDS_CLASS_BECOMING_FINAL);
                 }
-                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
+                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal' && !$this->isDeprecatedInVersion($class, null, $scope, $version)) {
                     $errors[] = $this->error(sprintf('"%s" extends "%s", which will become internal in %s. Stop extending it to stay compatible.', $class->getDisplayName(), $parent->getDisplayName(), $version), self::EXTENDS_CLASS_BECOMING_INTERNAL);
                 }
             }
@@ -63,10 +63,13 @@ final class FutureExtensionRule implements Rule
                     $arguments = $attribute->getArguments();
                     $version = $this->stringArgument($arguments, 'version', 0);
                     $name = $attribute->getName();
-                    if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesAbstract' && $override === null && !$class->isAbstract()) {
+                    if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesAbstract' && $override === null && !$class->isAbstract() && !$this->isDeprecatedInVersion($class, null, $scope, $version)) {
                         $errors[] = $this->error(sprintf('"%s::%s()" will become abstract in %s. Implement it in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $version, $class->getDisplayName()), self::MISSING_BECOMES_ABSTRACT_METHOD_IMPLEMENTATION);
                     }
                     if ($override === null) {
+                        continue;
+                    }
+                    if ($this->isDeprecatedInVersion($class, $override->getName(), $scope, $version)) {
                         continue;
                     }
                     if ($name === self::ATTRIBUTE_NAMESPACE . 'NewOptionalParameter') {
@@ -135,6 +138,17 @@ final class FutureExtensionRule implements Rule
         $value = $arguments[$name] ?? $arguments[$position] ?? '?';
 
         return is_string($value) ? $value : '?';
+    }
+
+    private function isDeprecatedInVersion(ClassReflection $class, ?string $method, Scope $scope, string $version): bool
+    {
+        return $this->hasDeprecationTagForVersion($class->getDeprecatedDescription(), $version)
+            || ($method !== null && $this->hasDeprecationTagForVersion($class->getMethod($method, $scope)->getDeprecatedDescription(), $version));
+    }
+
+    private function hasDeprecationTagForVersion(?string $description, string $version): bool
+    {
+        return $description !== null && preg_match(sprintf('/(?:^|\\s)tag:%s(?:\\s|$)/', preg_quote($version, '/')), $description) === 1;
     }
 
     private function error(string $message, string $identifier): IdentifierRuleError

--- a/src/Rule/FutureCompatibility/FutureExtensionRule.php
+++ b/src/Rule/FutureCompatibility/FutureExtensionRule.php
@@ -23,6 +23,13 @@ final class FutureExtensionRule implements Rule
 {
     private const ATTRIBUTE_NAMESPACE = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\';
 
+    private const EXTENDS_CLASS_BECOMING_FINAL = 'shopware.futureIncompatibility.extendsClassBecomingFinal';
+    private const EXTENDS_CLASS_BECOMING_INTERNAL = 'shopware.futureIncompatibility.extendsClassBecomingInternal';
+    private const MISSING_BECOMES_ABSTRACT_METHOD_IMPLEMENTATION = 'shopware.futureIncompatibility.missingBecomesAbstractMethodImplementation';
+    private const MISSING_NEW_OPTIONAL_PARAMETER_IN_OVERRIDE = 'shopware.futureIncompatibility.missingNewOptionalParameterInOverride';
+    private const PARAMETER_TYPE_WIDENING_IN_OVERRIDE = 'shopware.futureIncompatibility.parameterTypeWideningInOverride';
+    private const RETURN_TYPE_NARROWING_IN_OVERRIDE = 'shopware.futureIncompatibility.returnTypeNarrowingInOverride';
+
     public function __construct(private readonly AnnouncedTypeResolver $typeResolver) {}
 
     public function getNodeType(): string
@@ -40,10 +47,10 @@ final class FutureExtensionRule implements Rule
                 $arguments = $attribute->getArguments();
                 $version = $this->stringArgument($arguments, 'version', 0);
                 if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesFinal') {
-                    $errors[] = $this->error(sprintf('"%s" extends "%s", which will become final in %s. There is no forward-compatible way to keep extending it.', $class->getDisplayName(), $parent->getDisplayName(), $version));
+                    $errors[] = $this->error(sprintf('"%s" extends "%s", which will become final in %s. There is no forward-compatible way to keep extending it.', $class->getDisplayName(), $parent->getDisplayName(), $version), self::EXTENDS_CLASS_BECOMING_FINAL);
                 }
                 if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
-                    $errors[] = $this->error(sprintf('"%s" extends "%s", which will become internal in %s. Stop extending it to stay compatible.', $class->getDisplayName(), $parent->getDisplayName(), $version));
+                    $errors[] = $this->error(sprintf('"%s" extends "%s", which will become internal in %s. Stop extending it to stay compatible.', $class->getDisplayName(), $parent->getDisplayName(), $version), self::EXTENDS_CLASS_BECOMING_INTERNAL);
                 }
             }
 
@@ -57,7 +64,7 @@ final class FutureExtensionRule implements Rule
                     $version = $this->stringArgument($arguments, 'version', 0);
                     $name = $attribute->getName();
                     if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesAbstract' && $override === null && !$class->isAbstract()) {
-                        $errors[] = $this->error(sprintf('"%s::%s()" will become abstract in %s. Implement it in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $version, $class->getDisplayName()));
+                        $errors[] = $this->error(sprintf('"%s::%s()" will become abstract in %s. Implement it in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $version, $class->getDisplayName()), self::MISSING_BECOMES_ABSTRACT_METHOD_IMPLEMENTATION);
                     }
                     if ($override === null) {
                         continue;
@@ -66,7 +73,7 @@ final class FutureExtensionRule implements Rule
                         $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
                         if (is_string($parameter) && !$this->hasParameter($override, $parameter)) {
                             $type = $this->stringArgument($arguments, 'parameterType', 2);
-                            $errors[] = $this->error(sprintf('"%s::%s()" will get a new optional parameter $%s (%s) in %s. Add it to the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $parameter, $type, $version, $class->getDisplayName()));
+                            $errors[] = $this->error(sprintf('"%s::%s()" will get a new optional parameter $%s (%s) in %s. Add it to the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $parameter, $type, $version, $class->getDisplayName()), self::MISSING_NEW_OPTIONAL_PARAMETER_IN_OVERRIDE);
                         }
                     }
                     if ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterTypeWidening') {
@@ -75,7 +82,7 @@ final class FutureExtensionRule implements Rule
                         $announced = is_string($newType) ? $this->typeResolver->resolve($newType, $method->getDeclaringClass()->getName()) : null;
                         $current = is_string($parameter) ? $this->parameterType($class, $override->getName(), $parameter) : null;
                         if ($announced !== null && $current !== null && !$current->isSuperTypeOf($announced)->yes()) {
-                            $errors[] = $this->error(sprintf('Parameter $%s of "%s::%s()" will be widened to %s in %s. Widen the override in "%s" now to stay compatible with both versions.', $parameter, $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()));
+                            $errors[] = $this->error(sprintf('Parameter $%s of "%s::%s()" will be widened to %s in %s. Widen the override in "%s" now to stay compatible with both versions.', $parameter, $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()), self::PARAMETER_TYPE_WIDENING_IN_OVERRIDE);
                         }
                     }
                     if ($name === self::ATTRIBUTE_NAMESPACE . 'ReturnTypeNarrowing') {
@@ -83,7 +90,7 @@ final class FutureExtensionRule implements Rule
                         $announced = is_string($newType) && in_array(strtolower($newType), ['self', 'static', '$this'], true) ? new ObjectType($class->getName()) : (is_string($newType) ? $this->typeResolver->resolve($newType, $method->getDeclaringClass()->getName()) : null);
                         $return = $class->getNativeMethod($override->getName())->getVariants()[0]->getReturnType();
                         if ($announced !== null && !$announced->isSuperTypeOf($return)->yes()) {
-                            $errors[] = $this->error(sprintf('The return type of "%s::%s()" will be narrowed to %s in %s. Narrow the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()));
+                            $errors[] = $this->error(sprintf('The return type of "%s::%s()" will be narrowed to %s in %s. Narrow the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()), self::RETURN_TYPE_NARROWING_IN_OVERRIDE);
                         }
                     }
                 }
@@ -130,8 +137,8 @@ final class FutureExtensionRule implements Rule
         return is_string($value) ? $value : '?';
     }
 
-    private function error(string $message): IdentifierRuleError
+    private function error(string $message, string $identifier): IdentifierRuleError
     {
-        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility.extension')->build();
+        return RuleErrorBuilder::message($message)->identifier($identifier)->build();
     }
 }

--- a/src/Rule/FutureCompatibility/FutureExtensionRule.php
+++ b/src/Rule/FutureCompatibility/FutureExtensionRule.php
@@ -132,6 +132,6 @@ final class FutureExtensionRule implements Rule
 
     private function error(string $message): IdentifierRuleError
     {
-        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility')->build();
+        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility.extension')->build();
     }
 }

--- a/src/Rule/FutureCompatibility/FutureExtensionRule.php
+++ b/src/Rule/FutureCompatibility/FutureExtensionRule.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Rule\FutureCompatibility;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Reports extension classes incompatible with BC-change attributes announced by Core.
+ *
+ * @implements Rule<InClassNode>
+ * @internal
+ */
+final class FutureExtensionRule implements Rule
+{
+    private const ATTRIBUTE_NAMESPACE = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\';
+
+    public function __construct(private readonly AnnouncedTypeResolver $typeResolver) {}
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $class = $node->getClassReflection();
+        $errors = [];
+
+        foreach ($class->getParents() as $parent) {
+            foreach ($parent->getNativeReflection()->getAttributes() as $attribute) {
+                $arguments = $attribute->getArguments();
+                $version = $this->stringArgument($arguments, 'version', 0);
+                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesFinal') {
+                    $errors[] = $this->error(sprintf('"%s" extends "%s", which will become final in %s. There is no forward-compatible way to keep extending it.', $class->getDisplayName(), $parent->getDisplayName(), $version));
+                }
+                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesInternal') {
+                    $errors[] = $this->error(sprintf('"%s" extends "%s", which will become internal in %s. Stop extending it to stay compatible.', $class->getDisplayName(), $parent->getDisplayName(), $version));
+                }
+            }
+
+            foreach ($parent->getNativeReflection()->getMethods() as $method) {
+                if ($method->getDeclaringClass()->getName() !== $parent->getName()) {
+                    continue;
+                }
+                $override = $this->override($class, $method->getName());
+                foreach ($method->getAttributes() as $attribute) {
+                    $arguments = $attribute->getArguments();
+                    $version = $this->stringArgument($arguments, 'version', 0);
+                    $name = $attribute->getName();
+                    if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesAbstract' && $override === null && !$class->isAbstract()) {
+                        $errors[] = $this->error(sprintf('"%s::%s()" will become abstract in %s. Implement it in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $version, $class->getDisplayName()));
+                    }
+                    if ($override === null) {
+                        continue;
+                    }
+                    if ($name === self::ATTRIBUTE_NAMESPACE . 'NewOptionalParameter') {
+                        $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
+                        if (is_string($parameter) && !$this->hasParameter($override, $parameter)) {
+                            $type = $this->stringArgument($arguments, 'parameterType', 2);
+                            $errors[] = $this->error(sprintf('"%s::%s()" will get a new optional parameter $%s (%s) in %s. Add it to the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $parameter, $type, $version, $class->getDisplayName()));
+                        }
+                    }
+                    if ($name === self::ATTRIBUTE_NAMESPACE . 'ParameterTypeWidening') {
+                        $parameter = $arguments['parameterName'] ?? $arguments[1] ?? null;
+                        $newType = $arguments['newType'] ?? $arguments[2] ?? null;
+                        $announced = is_string($newType) ? $this->typeResolver->resolve($newType, $method->getDeclaringClass()->getName()) : null;
+                        $current = is_string($parameter) ? $this->parameterType($class, $override->getName(), $parameter) : null;
+                        if ($announced !== null && $current !== null && !$current->isSuperTypeOf($announced)->yes()) {
+                            $errors[] = $this->error(sprintf('Parameter $%s of "%s::%s()" will be widened to %s in %s. Widen the override in "%s" now to stay compatible with both versions.', $parameter, $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()));
+                        }
+                    }
+                    if ($name === self::ATTRIBUTE_NAMESPACE . 'ReturnTypeNarrowing') {
+                        $newType = $arguments['newType'] ?? $arguments[1] ?? null;
+                        $announced = is_string($newType) && in_array(strtolower($newType), ['self', 'static', '$this'], true) ? new ObjectType($class->getName()) : (is_string($newType) ? $this->typeResolver->resolve($newType, $method->getDeclaringClass()->getName()) : null);
+                        $return = $class->getNativeMethod($override->getName())->getVariants()[0]->getReturnType();
+                        if ($announced !== null && !$announced->isSuperTypeOf($return)->yes()) {
+                            $errors[] = $this->error(sprintf('The return type of "%s::%s()" will be narrowed to %s in %s. Narrow the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()));
+                        }
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    private function override(ClassReflection $class, string $method): ?\ReflectionMethod
+    {
+        $native = $class->getNativeReflection();
+
+        return $native->hasMethod($method) && $native->getMethod($method)->getDeclaringClass()->getName() === $native->getName() ? $native->getMethod($method) : null;
+    }
+
+    private function hasParameter(\ReflectionMethod $method, string $name): bool
+    {
+        foreach ($method->getParameters() as $parameter) {
+            if ($parameter->getName() === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function parameterType(ClassReflection $class, string $method, string $name): ?\PHPStan\Type\Type
+    {
+        foreach ($class->getNativeMethod($method)->getVariants()[0]->getParameters() as $parameter) {
+            if ($parameter->getName() === $name) {
+                return $parameter->getType();
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<int|string, mixed> $arguments */
+    private function stringArgument(array $arguments, string $name, int $position): string
+    {
+        $value = $arguments[$name] ?? $arguments[$position] ?? '?';
+
+        return is_string($value) ? $value : '?';
+    }
+
+    private function error(string $message): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message($message)->identifier('shopware.futureIncompatibility')->build();
+    }
+}

--- a/src/Rule/FutureCompatibility/FutureExtensionRule.php
+++ b/src/Rule/FutureCompatibility/FutureExtensionRule.php
@@ -63,7 +63,7 @@ final class FutureExtensionRule implements Rule
                     $arguments = $attribute->getArguments();
                     $version = $this->stringArgument($arguments, 'version', 0);
                     $name = $attribute->getName();
-                    if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesAbstract' && $override === null && !$class->isAbstract() && !$this->isDeprecatedInVersion($class, null, $scope, $version)) {
+                    if ($name === self::ATTRIBUTE_NAMESPACE . 'BecomesAbstract' && !$this->hasConcreteImplementation($class, $parent, $method->getName()) && !$class->isAbstract() && !$this->isDeprecatedInVersion($class, null, $scope, $version)) {
                         $errors[] = $this->error(sprintf('"%s::%s()" will become abstract in %s. Implement it in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $version, $class->getDisplayName()), self::MISSING_BECOMES_ABSTRACT_METHOD_IMPLEMENTATION);
                     }
                     if ($override === null) {
@@ -108,6 +108,18 @@ final class FutureExtensionRule implements Rule
         $native = $class->getNativeReflection();
 
         return $native->hasMethod($method) && $native->getMethod($method)->getDeclaringClass()->getName() === $native->getName() ? $native->getMethod($method) : null;
+    }
+
+    private function hasConcreteImplementation(ClassReflection $class, ClassReflection $abstractParent, string $method): bool
+    {
+        $native = $class->getNativeReflection();
+        if (!$native->hasMethod($method)) {
+            return false;
+        }
+
+        $implementation = $native->getMethod($method);
+
+        return !$implementation->isAbstract() && $implementation->getDeclaringClass()->getName() !== $abstractParent->getName();
     }
 
     private function hasParameter(\ReflectionMethod $method, string $name): bool

--- a/src/Rule/FutureCompatibility/FutureExtensionRule.php
+++ b/src/Rule/FutureCompatibility/FutureExtensionRule.php
@@ -29,6 +29,7 @@ final class FutureExtensionRule implements Rule
     private const MISSING_NEW_OPTIONAL_PARAMETER_IN_OVERRIDE = 'shopware.futureIncompatibility.missingNewOptionalParameterInOverride';
     private const PARAMETER_TYPE_WIDENING_IN_OVERRIDE = 'shopware.futureIncompatibility.parameterTypeWideningInOverride';
     private const RETURN_TYPE_NARROWING_IN_OVERRIDE = 'shopware.futureIncompatibility.returnTypeNarrowingInOverride';
+    private const PROPERTY_REDECLARATION = 'shopware.futureIncompatibility.propertyRedeclaration';
 
     public function __construct(private readonly AnnouncedTypeResolver $typeResolver) {}
 
@@ -96,6 +97,33 @@ final class FutureExtensionRule implements Rule
                             $errors[] = $this->error(sprintf('The return type of "%s::%s()" will be narrowed to %s in %s. Narrow the override in "%s" now to stay compatible with both versions.', $parent->getDisplayName(), $method->getName(), $newType, $version, $class->getDisplayName()), self::RETURN_TYPE_NARROWING_IN_OVERRIDE);
                         }
                     }
+                }
+            }
+
+            foreach ($parent->getNativeReflection()->getProperties() as $property) {
+                $native = $class->getNativeReflection();
+                if ($property->getDeclaringClass()->getName() !== $parent->getName()
+                    || !$native->hasProperty($property->getName())
+                    || $native->getProperty($property->getName())->getDeclaringClass()->getName() !== $native->getName()
+                ) {
+                    continue;
+                }
+
+                foreach ($property->getAttributes() as $attribute) {
+                    $arguments = $attribute->getArguments();
+                    $version = $this->stringArgument($arguments, 'version', 0);
+                    $name = $attribute->getName();
+                    if (!in_array($name, [
+                        self::ATTRIBUTE_NAMESPACE . 'BecomesReadonly',
+                        self::ATTRIBUTE_NAMESPACE . 'PropertyTypeNarrowing',
+                        self::ATTRIBUTE_NAMESPACE . 'PropertyTypeWidening',
+                    ], true)
+                        && !($name === self::ATTRIBUTE_NAMESPACE . 'VisibilityChange' && ($arguments['newVisibility'] ?? $arguments[1] ?? null) === 'private')
+                    ) {
+                        continue;
+                    }
+
+                    $errors[] = $this->error(sprintf('Property "%s::$%s" redeclares "%s::$%s", which has an incompatible property change in %s. Stop redeclaring it; there is no forward-compatible declaration.', $class->getDisplayName(), $property->getName(), $parent->getDisplayName(), $property->getName(), $version), self::PROPERTY_REDECLARATION);
                 }
             }
         }

--- a/src/Rule/FutureCompatibility/FuturePropertyCompatibilityRule.php
+++ b/src/Rule/FutureCompatibility/FuturePropertyCompatibilityRule.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Rule\FutureCompatibility;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Reports extension assignments incompatible with BC-change attributes announced by Core.
+ *
+ * @implements Rule<Expr>
+ * @internal
+ */
+final class FuturePropertyCompatibilityRule implements Rule
+{
+    private const ATTRIBUTE_NAMESPACE = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly AnnouncedTypeResolver $typeResolver,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return Expr::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Assign || (!$node->var instanceof PropertyFetch && !$node->var instanceof StaticPropertyFetch) || !$node->var->name instanceof Identifier) {
+            return [];
+        }
+
+        $propertyName = $node->var->name->toString();
+        foreach ($this->properties($node->var, $propertyName, $scope) as $property) {
+            if ($this->isDeclaredInCurrentClass($property, $scope)) {
+                continue;
+            }
+
+            foreach ($property->getAttributes() as $attribute) {
+                $arguments = $attribute->getArguments();
+                $version = $this->stringArgument($arguments, 'version', 0);
+
+                if ($attribute->getName() === self::ATTRIBUTE_NAMESPACE . 'BecomesReadonly') {
+                    return [$this->error(
+                        sprintf('Property "%s::$%s" will become readonly in %s. Stop assigning to it outside the declaring class.', $property->getDeclaringClass()->getName(), $property->getName(), $version),
+                        'propertyBecomesReadonly',
+                    )];
+                }
+
+                if ($attribute->getName() !== self::ATTRIBUTE_NAMESPACE . 'PropertyTypeNarrowing') {
+                    continue;
+                }
+
+                $newType = $arguments['newType'] ?? $arguments[1] ?? null;
+                $announced = is_string($newType) ? $this->typeResolver->resolve($newType, $property->getDeclaringClass()->getName()) : null;
+                if ($announced === null) {
+                    continue;
+                }
+
+                $actual = $scope->getType($node->expr);
+                if (!$announced->isSuperTypeOf($actual)->no()) {
+                    continue;
+                }
+
+                return [$this->error(
+                    sprintf('Property "%s::$%s" will be narrowed to %s in %s, but %s is assigned. Assign %s to stay compatible with both versions.', $property->getDeclaringClass()->getName(), $property->getName(), $newType, $version, $actual->describe(VerbosityLevel::typeOnly()), $newType),
+                    'propertyTypeNarrowing',
+                )];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return iterable<\ReflectionProperty>
+     */
+    private function properties(PropertyFetch|StaticPropertyFetch $fetch, string $propertyName, Scope $scope): iterable
+    {
+        $classes = [];
+        if ($fetch instanceof PropertyFetch) {
+            $classes = $scope->getType($fetch->var)->getObjectClassReflections();
+        } elseif ($fetch->class instanceof Name) {
+            $className = $scope->resolveName($fetch->class);
+            if ($this->reflectionProvider->hasClass($className)) {
+                $classes[] = $this->reflectionProvider->getClass($className);
+            }
+        }
+
+        foreach ($classes as $class) {
+            $native = $class->getNativeReflection();
+            if ($native->hasProperty($propertyName)) {
+                yield $native->getProperty($propertyName);
+            }
+        }
+    }
+
+    private function isDeclaredInCurrentClass(\ReflectionProperty $property, Scope $scope): bool
+    {
+        return $scope->isInClass()
+            && $scope->getClassReflection()->getName() === $property->getDeclaringClass()->getName();
+    }
+
+    /** @param array<int|string, mixed> $arguments */
+    private function stringArgument(array $arguments, string $name, int $position): string
+    {
+        $value = $arguments[$name] ?? $arguments[$position] ?? '?';
+
+        return is_string($value) ? $value : '?';
+    }
+
+    private function error(string $message, string $identifier): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message($message)
+            ->identifier('shopware.futureIncompatibility.' . $identifier)
+            ->build();
+    }
+}

--- a/src/Rule/InternalMethodCallRule.php
+++ b/src/Rule/InternalMethodCallRule.php
@@ -44,6 +44,10 @@ class InternalMethodCallRule implements Rule
         $methodCalledOnType = $scope->getType($node->var);
 
         foreach ($methodCalledOnType->getObjectClassNames() as $class) {
+            if (!$this->reflectionProvider->hasClass($class)) {
+                continue;
+            }
+
             $classInfo = $this->reflectionProvider->getClass($class);
             try {
                 $methodDetails = $classInfo->getMethod($methodName, $scope);

--- a/src/Type/FuturePropertyTypeExtension.php
+++ b/src/Type/FuturePropertyTypeExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Type;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ExpressionTypeResolverExtension;
+use PHPStan\Type\Type;
+use Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver;
+
+/** @internal */
+final readonly class FuturePropertyTypeExtension implements ExpressionTypeResolverExtension
+{
+    private const PROPERTY_TYPE_WIDENING = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\PropertyTypeWidening';
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private AnnouncedTypeResolver $typeResolver,
+    ) {}
+
+    public function getType(Expr $expr, Scope $scope): ?Type
+    {
+        if (($expr instanceof PropertyFetch || $expr instanceof StaticPropertyFetch) && $expr->name instanceof Identifier) {
+            foreach ($this->propertyClasses($expr, $scope) as $class) {
+                $native = $class->getNativeReflection();
+                if (!$native->hasProperty($expr->name->toString())) {
+                    continue;
+                }
+
+                foreach ($native->getProperty($expr->name->toString())->getAttributes() as $attribute) {
+                    if ($attribute->getName() === self::PROPERTY_TYPE_WIDENING) {
+                        $newType = $attribute->getArguments()['newType'] ?? $attribute->getArguments()[1] ?? null;
+
+                        return is_string($newType) ? $this->typeResolver->resolve($newType, $native->getName()) : null;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<\PHPStan\Reflection\ClassReflection> */
+    private function propertyClasses(PropertyFetch|StaticPropertyFetch $fetch, Scope $scope): array
+    {
+        if ($fetch instanceof PropertyFetch) {
+            return $scope->getType($fetch->var)->getObjectClassReflections();
+        }
+        if ($fetch->class instanceof Name) {
+            $className = $scope->resolveName($fetch->class);
+
+            return $this->reflectionProvider->hasClass($className) ? [$this->reflectionProvider->getClass($className)] : [];
+        }
+
+        return [];
+    }
+}

--- a/src/Type/FutureReturnTypeExtension.php
+++ b/src/Type/FutureReturnTypeExtension.php
@@ -31,7 +31,7 @@ final readonly class FutureReturnTypeExtension implements ExpressionTypeResolver
     {
         if ($expr instanceof MethodCall && $expr->name instanceof Identifier) {
             foreach ($scope->getType($expr->var)->getObjectClassReflections() as $class) {
-                $type = $this->returnType($class->getNativeReflection(), $expr->name->toString());
+                $type = $this->returnType($class->getNativeReflection(), $expr->name->toString(), $scope);
                 if ($type !== null) {
                     return $type;
                 }
@@ -42,13 +42,13 @@ final readonly class FutureReturnTypeExtension implements ExpressionTypeResolver
         if ($expr instanceof StaticCall && $expr->name instanceof Identifier && $expr->class instanceof Name) {
             $class = $scope->resolveName($expr->class);
 
-            return $this->reflectionProvider->hasClass($class) ? $this->returnType($this->reflectionProvider->getClass($class)->getNativeReflection(), $expr->name->toString()) : null;
+            return $this->reflectionProvider->hasClass($class) ? $this->returnType($this->reflectionProvider->getClass($class)->getNativeReflection(), $expr->name->toString(), $scope) : null;
         }
 
         return null;
     }
 
-    private function returnType(ReflectionClass|ReflectionEnum $class, string $method): ?Type
+    private function returnType(ReflectionClass|ReflectionEnum $class, string $method, Scope $scope): ?Type
     {
         if (!$class->hasMethod($method)) {
             return null;
@@ -58,11 +58,27 @@ final readonly class FutureReturnTypeExtension implements ExpressionTypeResolver
             if ($attribute->getName() === self::RETURN_TYPE_WIDENING) {
                 $arguments = $attribute->getArguments();
                 $type = $arguments['newType'] ?? $arguments[1] ?? null;
+                $version = $arguments['version'] ?? $arguments[0] ?? null;
 
-                return is_string($type) ? $this->typeResolver->resolve($type, $reflection->getDeclaringClass()->getName()) : null;
+                if (!is_string($type) || !is_string($version) || $this->isDeprecatedInVersion($scope, $version)) {
+                    return null;
+                }
+
+                return $this->typeResolver->resolve($type, $reflection->getDeclaringClass()->getName());
             }
         }
 
         return null;
+    }
+
+    private function isDeprecatedInVersion(Scope $scope, string $version): bool
+    {
+        return $this->hasDeprecationTagForVersion($scope->getClassReflection()?->getDeprecatedDescription(), $version)
+            || $this->hasDeprecationTagForVersion($scope->getFunction()?->getDeprecatedDescription(), $version);
+    }
+
+    private function hasDeprecationTagForVersion(?string $description, string $version): bool
+    {
+        return $description !== null && preg_match(sprintf('/(?:^|\\s)tag:%s(?:\\s|$)/', preg_quote($version, '/')), $description) === 1;
     }
 }

--- a/src/Type/FutureReturnTypeExtension.php
+++ b/src/Type/FutureReturnTypeExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Type;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionClass;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnum;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ExpressionTypeResolverExtension;
+use PHPStan\Type\Type;
+use Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver;
+
+/** @internal */
+final readonly class FutureReturnTypeExtension implements ExpressionTypeResolverExtension
+{
+    private const RETURN_TYPE_WIDENING = 'Shopware\\Core\\Framework\\Deprecation\\BCChange\\ReturnTypeWidening';
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private AnnouncedTypeResolver $typeResolver,
+    ) {}
+
+    public function getType(Expr $expr, Scope $scope): ?Type
+    {
+        if ($expr instanceof MethodCall && $expr->name instanceof Identifier) {
+            foreach ($scope->getType($expr->var)->getObjectClassReflections() as $class) {
+                $type = $this->returnType($class->getNativeReflection(), $expr->name->toString());
+                if ($type !== null) {
+                    return $type;
+                }
+            }
+
+            return null;
+        }
+        if ($expr instanceof StaticCall && $expr->name instanceof Identifier && $expr->class instanceof Name) {
+            $class = $scope->resolveName($expr->class);
+
+            return $this->reflectionProvider->hasClass($class) ? $this->returnType($this->reflectionProvider->getClass($class)->getNativeReflection(), $expr->name->toString()) : null;
+        }
+
+        return null;
+    }
+
+    private function returnType(ReflectionClass|ReflectionEnum $class, string $method): ?Type
+    {
+        if (!$class->hasMethod($method)) {
+            return null;
+        }
+        $reflection = $class->getMethod($method);
+        foreach ($reflection->getAttributes() as $attribute) {
+            if ($attribute->getName() === self::RETURN_TYPE_WIDENING) {
+                $arguments = $attribute->getArguments();
+                $type = $arguments['newType'] ?? $arguments[1] ?? null;
+
+                return is_string($type) ? $this->typeResolver->resolve($type, $reflection->getDeclaringClass()->getName()) : null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Rule/FutureCallSiteRuleTest.php
+++ b/tests/Rule/FutureCallSiteRuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver;
+use Shopware\PhpStan\Rule\FutureCompatibility\FutureCallSiteRule;
+
+/**
+ * @extends RuleTestCase<FutureCallSiteRule>
+ * @internal
+ */
+class FutureCallSiteRuleTest extends RuleTestCase
+{
+    public function testReportsFutureIncompatibleCallSite(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/FutureCallSiteRule/call-site.php'], [
+            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureSubject::find()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 21],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $reflectionProvider = self::createReflectionProvider();
+
+        return new FutureCallSiteRule($reflectionProvider, new AnnouncedTypeResolver(
+            self::getContainer()->getByType(TypeStringResolver::class),
+            $reflectionProvider,
+        ));
+    }
+}

--- a/tests/Rule/FutureCallSiteRuleTest.php
+++ b/tests/Rule/FutureCallSiteRuleTest.php
@@ -29,6 +29,7 @@ class FutureCallSiteRuleTest extends RuleTestCase
             ['The default value of parameter $strict of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withDefaultValue()" will change in v6.8.0. Pass the current default explicitly to retain current behavior.', 60],
             ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 62],
             ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 63],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 100],
         ]);
     }
 

--- a/tests/Rule/FutureCallSiteRuleTest.php
+++ b/tests/Rule/FutureCallSiteRuleTest.php
@@ -19,17 +19,19 @@ class FutureCallSiteRuleTest extends RuleTestCase
     public function testReportsFutureIncompatibleCallSites(): void
     {
         $this->analyse([__DIR__ . '/fixtures/FutureCallSiteRule/call-site.php'], [
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 49],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::becomesProtected()" will become protected in v6.8.0. This call will break; stop calling it from outside that scope.', 50],
-            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 51],
-            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 52],
-            ['Parameter $oldName of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRename()" will be renamed to $newName in v6.8.0. A named argument cannot be compatible with both versions; pass it positionally.', 55],
-            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNarrowing()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 57],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNewRequired()" will require a new parameter $context in v6.8.0. Pass it positionally now to stay compatible with both versions.', 58],
-            ['The default value of parameter $strict of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withDefaultValue()" will change in v6.8.0. Pass the current default explicitly to retain current behavior.', 60],
-            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 62],
-            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 63],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 100],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 55],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::becomesProtected()" will become protected in v6.8.0. This call will break; stop calling it from outside that scope.', 56],
+            ['Property "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::$becomesProtectedProperty" will become protected in v6.8.0. This access will break; stop accessing it from outside that scope.', 57],
+            ['Property "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::$becomesPrivateProperty" will become private in v6.8.0. This access will break; stop accessing it from outside that scope.', 58],
+            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 59],
+            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 60],
+            ['Parameter $oldName of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRename()" will be renamed to $newName in v6.8.0. A named argument cannot be compatible with both versions; pass it positionally.', 63],
+            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNarrowing()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 65],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNewRequired()" will require a new parameter $context in v6.8.0. Pass it positionally now to stay compatible with both versions.', 66],
+            ['The default value of parameter $strict of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withDefaultValue()" will change in v6.8.0. Pass the current default explicitly to retain current behavior.', 68],
+            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 70],
+            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 71],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 109],
         ]);
     }
 

--- a/tests/Rule/FutureCallSiteRuleTest.php
+++ b/tests/Rule/FutureCallSiteRuleTest.php
@@ -19,7 +19,7 @@ class FutureCallSiteRuleTest extends RuleTestCase
     public function testReportsFutureIncompatibleCallSite(): void
     {
         $this->analyse([__DIR__ . '/fixtures/FutureCallSiteRule/call-site.php'], [
-            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureSubject::find()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 21],
+            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureSubject::find()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 19],
         ]);
     }
 

--- a/tests/Rule/FutureCallSiteRuleTest.php
+++ b/tests/Rule/FutureCallSiteRuleTest.php
@@ -16,10 +16,19 @@ use Shopware\PhpStan\Rule\FutureCompatibility\FutureCallSiteRule;
  */
 class FutureCallSiteRuleTest extends RuleTestCase
 {
-    public function testReportsFutureIncompatibleCallSite(): void
+    public function testReportsFutureIncompatibleCallSites(): void
     {
         $this->analyse([__DIR__ . '/fixtures/FutureCallSiteRule/call-site.php'], [
-            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureSubject::find()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 19],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 49],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::becomesProtected()" will become protected in v6.8.0. This call will break; stop calling it from outside that scope.', 50],
+            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 51],
+            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 52],
+            ['Parameter $oldName of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRename()" will be renamed to $newName in v6.8.0. A named argument cannot be compatible with both versions; pass it positionally.', 55],
+            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNarrowing()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 57],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNewRequired()" will require a new parameter $context in v6.8.0. Pass it positionally now to stay compatible with both versions.', 58],
+            ['The default value of parameter $strict of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withDefaultValue()" will change in v6.8.0. Pass the current default explicitly to retain current behavior.', 60],
+            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 62],
+            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 63],
         ]);
     }
 

--- a/tests/Rule/FutureExtensionRuleTest.php
+++ b/tests/Rule/FutureExtensionRuleTest.php
@@ -25,7 +25,7 @@ class FutureExtensionRuleTest extends RuleTestCase
             ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::toBeAbstract()" will become abstract in v6.8.0. Implement it in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
             ['Parameter $value of "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::widensParameter()" will be widened to string|int in v6.8.0. Widen the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
             ['The return type of "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::narrowsReturn()" will be narrowed to string in v6.8.0. Narrow the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\LaterDeprecatedExtension" extends "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\WillBeFinal", which will become final in v6.8.0. There is no forward-compatible way to keep extending it.', 95],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\LaterDeprecatedExtension" extends "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\WillBeFinal", which will become final in v6.8.0. There is no forward-compatible way to keep extending it.', 102],
         ]);
     }
 

--- a/tests/Rule/FutureExtensionRuleTest.php
+++ b/tests/Rule/FutureExtensionRuleTest.php
@@ -25,6 +25,7 @@ class FutureExtensionRuleTest extends RuleTestCase
             ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::toBeAbstract()" will become abstract in v6.8.0. Implement it in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
             ['Parameter $value of "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::widensParameter()" will be widened to string|int in v6.8.0. Widen the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
             ['The return type of "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::narrowsReturn()" will be narrowed to string in v6.8.0. Narrow the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\LaterDeprecatedExtension" extends "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\WillBeFinal", which will become final in v6.8.0. There is no forward-compatible way to keep extending it.', 95],
         ]);
     }
 

--- a/tests/Rule/FutureExtensionRuleTest.php
+++ b/tests/Rule/FutureExtensionRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver;
+use Shopware\PhpStan\Rule\FutureCompatibility\FutureExtensionRule;
+
+/**
+ * @extends RuleTestCase<FutureExtensionRule>
+ * @internal
+ */
+class FutureExtensionRuleTest extends RuleTestCase
+{
+    public function testReportsFutureIncompatibleExtensions(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/FutureExtensionRule/future-extenders.php'], [
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtendsFinal" extends "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\WillBeFinal", which will become final in v6.8.0. There is no forward-compatible way to keep extending it.', 42],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtendsInternal" extends "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\WillBeInternal", which will become internal in v6.8.0. Stop extending it to stay compatible.', 44],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::gainsParameter()" will get a new optional parameter $states (array) in v6.8.0. Add it to the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::toBeAbstract()" will become abstract in v6.8.0. Implement it in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
+            ['Parameter $value of "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::widensParameter()" will be widened to string|int in v6.8.0. Widen the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
+            ['The return type of "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\ExtensionPointBase::narrowsReturn()" will be narrowed to string in v6.8.0. Narrow the override in "Shopware\\PhpStan\\Tests\\Fixture\\FutureExtensionRule\\IncompatibleExtension" now to stay compatible with both versions.', 48],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $reflectionProvider = self::createReflectionProvider();
+
+        return new FutureExtensionRule(new AnnouncedTypeResolver(
+            self::getContainer()->getByType(TypeStringResolver::class),
+            $reflectionProvider,
+        ));
+    }
+}

--- a/tests/Rule/FuturePropertyCompatibilityRuleTest.php
+++ b/tests/Rule/FuturePropertyCompatibilityRuleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver;
+use Shopware\PhpStan\Rule\FutureCompatibility\FuturePropertyCompatibilityRule;
+
+/**
+ * @extends RuleTestCase<FuturePropertyCompatibilityRule>
+ * @internal
+ */
+class FuturePropertyCompatibilityRuleTest extends RuleTestCase
+{
+    public function testReportsAssignmentsIncompatibleWithFutureProperties(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/FuturePropertyCompatibilityRule/property-assignment.php'], [
+            ['Property "Shopware\\PhpStan\\Tests\\Fixture\\FuturePropertyCompatibilityRule\\FutureNarrowedProperty::$value" will be narrowed to string in v6.8.0, but null is assigned. Assign string to stay compatible with both versions.', 26],
+            ['Property "Shopware\\PhpStan\\Tests\\Fixture\\FuturePropertyCompatibilityRule\\FutureReadonlyProperty::$value" will become readonly in v6.8.0. Stop assigning to it outside the declaring class.', 39],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $reflectionProvider = self::createReflectionProvider();
+
+        return new FuturePropertyCompatibilityRule($reflectionProvider, new AnnouncedTypeResolver(
+            self::getContainer()->getByType(TypeStringResolver::class),
+            $reflectionProvider,
+        ));
+    }
+}

--- a/tests/Rule/InternalMethodCallRuleTest.php
+++ b/tests/Rule/InternalMethodCallRuleTest.php
@@ -34,4 +34,11 @@ class InternalMethodCallRuleTest extends RuleTestCase
             ],
         ]);
     }
+
+    public function testUnknownClassDoesNotCauseAnInternalError(): void
+    {
+        $this->analyse([
+            __DIR__ . '/fixtures/InternalMethodCallRule/app/Test/unknown-class.php',
+        ], []);
+    }
 }

--- a/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/correct-usage.php
+++ b/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/correct-usage.php
@@ -39,24 +39,24 @@ class CorrectUsage
     // Fluent builder – create() + withSecure(true)
     public function cookieCreateFluentWithSecureTrue(): void
     {
-        Cookie::create('session')->withSecure(true);
+        Cookie::create(name: 'session', secure: true)->withSecure(true);
     }
 
     // Fluent builder – create() + withSecure() default
     public function cookieCreateFluentWithSecureDefault(): void
     {
-        Cookie::create('session')->withSecure();
+        Cookie::create(name: 'session', secure: true)->withSecure();
     }
 
     // Fluent builder – new Cookie + withSecure(true)
     public function newCookieFluentWithSecureTrue(): void
     {
-        (new Cookie('session'))->withSecure(true);
+        (new Cookie(name: 'session', secure: true))->withSecure(true);
     }
 
     // Fluent builder – new Cookie + withSecure() default
     public function newCookieFluentWithSecureDefault(): void
     {
-        (new Cookie('session'))->withSecure();
+        (new Cookie(name: 'session', secure: true))->withSecure();
     }
 }

--- a/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/correct-usage.php
+++ b/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/correct-usage.php
@@ -39,24 +39,24 @@ class CorrectUsage
     // Fluent builder – create() + withSecure(true)
     public function cookieCreateFluentWithSecureTrue(): void
     {
-        Cookie::create(name: 'session', secure: true)->withSecure(true);
+        Cookie::create('session')->withSecure(true);
     }
 
     // Fluent builder – create() + withSecure() default
     public function cookieCreateFluentWithSecureDefault(): void
     {
-        Cookie::create(name: 'session', secure: true)->withSecure();
+        Cookie::create('session')->withSecure();
     }
 
     // Fluent builder – new Cookie + withSecure(true)
     public function newCookieFluentWithSecureTrue(): void
     {
-        (new Cookie(name: 'session', secure: true))->withSecure(true);
+        (new Cookie('session'))->withSecure(true);
     }
 
     // Fluent builder – new Cookie + withSecure() default
     public function newCookieFluentWithSecureDefault(): void
     {
-        (new Cookie(name: 'session', secure: true))->withSecure();
+        (new Cookie('session'))->withSecure();
     }
 }

--- a/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
+++ b/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
@@ -2,20 +2,72 @@
 
 declare(strict_types=1);
 
-namespace Shopware\PhpStan\Tests\Fixture;
+namespace Shopware\PhpStan\Tests\Fixture\FutureCallSiteRule;
 
+use Shopware\Core\Framework\Deprecation\BCChange\BecomesInternal;
+use Shopware\Core\Framework\Deprecation\BCChange\NewRequiredParameter;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterNameChange;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterRemoval;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeNarrowing;
+use Shopware\Core\Framework\Deprecation\BCChange\VisibilityChange;
 
-class FutureSubject
+class BCSubject
 {
+    #[BecomesInternal(version: 'v6.8.0')]
+    public function internalMethod(): void {}
+
+    #[VisibilityChange(version: 'v6.8.0', newVisibility: 'protected')]
+    public function becomesProtected(): void {}
+
+    #[ParameterRemoval(version: 'v6.8.0', parameterName: 'options')]
+    public function withRemoval(?array $options = null): void {}
+
+    #[ParameterNameChange(version: 'v6.8.0', parameterName: 'oldName', newName: 'newName')]
+    public function withRename(string $oldName): void {}
+
     #[ParameterTypeNarrowing(version: 'v6.8.0', parameterName: 'id', newType: 'string')]
-    public function find(string|int $id): void {}
+    public function withNarrowing(int|string $id): void {}
+
+    #[NewRequiredParameter(version: 'v6.8.0', parameterName: 'context', parameterType: 'string')]
+    public function withNewRequired(string $id): void {}
+
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'strict', newDefaultValue: true)]
+    public function withDefaultValue(bool $strict = false): void {}
 }
 
-class FutureCaller
+#[BecomesInternal(version: 'v6.8.0')]
+class InternalSubject
 {
-    public function find(FutureSubject $subject): void
+    public function anyMethod(): void {}
+}
+
+class Caller
+{
+    public function trigger(BCSubject $subject, InternalSubject $internal): void
     {
-        $subject->find(1);
+        $subject->internalMethod();
+        $subject->becomesProtected();
+        $subject->withRemoval(['a']);
+        $subject->withRemoval(options: ['a']);
+        $subject->withRemoval();
+        $subject->withRename('x');
+        $subject->withRename(oldName: 'x');
+        $subject->withNarrowing('ok');
+        $subject->withNarrowing(123);
+        $subject->withNewRequired('id');
+        $subject->withNewRequired('id', 'context');
+        $subject->withDefaultValue();
+        $subject->withDefaultValue(false);
+        $internal->anyMethod();
+        new InternalSubject();
+    }
+}
+
+class SubclassCaller extends BCSubject
+{
+    public function allowed(): void
+    {
+        $this->becomesProtected();
     }
 }

--- a/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
+++ b/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
@@ -9,9 +9,7 @@ use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeNarrowing;
 class FutureSubject
 {
     #[ParameterTypeNarrowing(version: 'v6.8.0', parameterName: 'id', newType: 'string')]
-    public function find(string|int $id): void
-    {
-    }
+    public function find(string|int $id): void {}
 }
 
 class FutureCaller

--- a/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
+++ b/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
@@ -14,6 +14,12 @@ use Shopware\Core\Framework\Deprecation\BCChange\VisibilityChange;
 
 class BCSubject
 {
+    #[VisibilityChange(version: 'v6.8.0', newVisibility: 'protected')]
+    public string $becomesProtectedProperty = 'value';
+
+    #[VisibilityChange(version: 'v6.8.0', newVisibility: 'private')]
+    public static string $becomesPrivateProperty = 'value';
+
     #[BecomesInternal(version: 'v6.8.0')]
     public function internalMethod(): void {}
 
@@ -48,6 +54,8 @@ class Caller
     {
         $subject->internalMethod();
         $subject->becomesProtected();
+        $subject->becomesProtectedProperty;
+        BCSubject::$becomesPrivateProperty;
         $subject->withRemoval(['a']);
         $subject->withRemoval(options: ['a']);
         $subject->withRemoval();
@@ -69,6 +77,7 @@ class SubclassCaller extends BCSubject
     public function allowed(): void
     {
         $this->becomesProtected();
+        $this->becomesProtectedProperty;
     }
 }
 

--- a/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
+++ b/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Fixture;
+
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeNarrowing;
+
+class FutureSubject
+{
+    #[ParameterTypeNarrowing(version: 'v6.8.0', parameterName: 'id', newType: 'string')]
+    public function find(string|int $id): void
+    {
+    }
+}
+
+class FutureCaller
+{
+    public function find(FutureSubject $subject): void
+    {
+        $subject->find(1);
+    }
+}

--- a/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
+++ b/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
@@ -71,3 +71,32 @@ class SubclassCaller extends BCSubject
         $this->becomesProtected();
     }
 }
+
+/** @deprecated tag:v6.8.0 - This extension will be removed with the next major version. */
+class DeprecatedCaller
+{
+    public function trigger(BCSubject $subject, InternalSubject $internal): void
+    {
+        $subject->internalMethod();
+        $internal->anyMethod();
+    }
+}
+
+class MethodDeprecatedCaller
+{
+    /** @deprecated tag:v6.8.0 - This extension hook will be removed with the next major version. */
+    public function trigger(BCSubject $subject, InternalSubject $internal): void
+    {
+        $subject->internalMethod();
+        $internal->anyMethod();
+    }
+}
+
+class LaterDeprecatedCaller
+{
+    /** @deprecated tag:v6.9.0 - This extension hook remains available in v6.8.0. */
+    public function trigger(BCSubject $subject): void
+    {
+        $subject->internalMethod();
+    }
+}

--- a/tests/Rule/fixtures/FutureExtensionRule/future-extenders.php
+++ b/tests/Rule/fixtures/FutureExtensionRule/future-extenders.php
@@ -71,6 +71,13 @@ class CompatibleExtension extends ExtensionPointBase
     }
 }
 
+class IntermediateExtension extends ExtensionPointBase
+{
+    public function toBeAbstract(): void {}
+}
+
+class IndirectExtension extends IntermediateExtension {}
+
 /** @deprecated tag:v6.8.0 - This extension will be removed with the next major version. */
 class DeprecatedExtension extends WillBeFinal {}
 

--- a/tests/Rule/fixtures/FutureExtensionRule/future-extenders.php
+++ b/tests/Rule/fixtures/FutureExtensionRule/future-extenders.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Fixture\FutureExtensionRule;
+
+use Shopware\Core\Framework\Deprecation\BCChange\BecomesAbstract;
+use Shopware\Core\Framework\Deprecation\BCChange\BecomesFinal;
+use Shopware\Core\Framework\Deprecation\BCChange\BecomesInternal;
+use Shopware\Core\Framework\Deprecation\BCChange\ClassHierarchyChange;
+use Shopware\Core\Framework\Deprecation\BCChange\NewOptionalParameter;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeWidening;
+use Shopware\Core\Framework\Deprecation\BCChange\ReturnTypeNarrowing;
+
+#[BecomesFinal(version: 'v6.8.0')]
+class WillBeFinal {}
+
+#[BecomesInternal(version: 'v6.8.0')]
+class WillBeInternal {}
+
+#[ClassHierarchyChange(version: 'v6.8.0', description: 'Will extend EntityCollection directly.')]
+class HierarchyChanges {}
+
+abstract class ExtensionPointBase
+{
+    #[BecomesAbstract(version: 'v6.8.0')]
+    public function toBeAbstract(): void {}
+
+    #[NewOptionalParameter(version: 'v6.8.0', parameterName: 'states', parameterType: 'array')]
+    public function gainsParameter(string $existing): void {}
+
+    #[ParameterTypeWidening(version: 'v6.8.0', parameterName: 'value', newType: 'string|int')]
+    public function widensParameter(string $value): void {}
+
+    #[ReturnTypeNarrowing(version: 'v6.8.0', newType: 'string')]
+    public function narrowsReturn(): ?string
+    {
+        return null;
+    }
+}
+
+class ExtendsFinal extends WillBeFinal {}
+
+class ExtendsInternal extends WillBeInternal {}
+
+class ExtendsChangingHierarchy extends HierarchyChanges {}
+
+class IncompatibleExtension extends ExtensionPointBase
+{
+    public function gainsParameter(string $existing): void {}
+
+    public function widensParameter(string $value): void {}
+
+    public function narrowsReturn(): ?string
+    {
+        return null;
+    }
+}
+
+class CompatibleExtension extends ExtensionPointBase
+{
+    public function toBeAbstract(): void {}
+
+    public function gainsParameter(string $existing, array $states = []): void {}
+
+    public function widensParameter(string|int $value): void {}
+
+    public function narrowsReturn(): string
+    {
+        return 'x';
+    }
+}

--- a/tests/Rule/fixtures/FutureExtensionRule/future-extenders.php
+++ b/tests/Rule/fixtures/FutureExtensionRule/future-extenders.php
@@ -70,3 +70,26 @@ class CompatibleExtension extends ExtensionPointBase
         return 'x';
     }
 }
+
+/** @deprecated tag:v6.8.0 - This extension will be removed with the next major version. */
+class DeprecatedExtension extends WillBeFinal {}
+
+class MethodDeprecatedExtension extends ExtensionPointBase
+{
+    public function toBeAbstract(): void {}
+
+    /** @deprecated tag:v6.8.0 - This extension hook will be removed with the next major version. */
+    public function gainsParameter(string $existing): void {}
+
+    /** @deprecated tag:v6.8.0 - This extension hook will be removed with the next major version. */
+    public function widensParameter(string $value): void {}
+
+    /** @deprecated tag:v6.8.0 - This extension hook will be removed with the next major version. */
+    public function narrowsReturn(): ?string
+    {
+        return null;
+    }
+}
+
+/** @deprecated tag:v6.9.0 - This extension remains available in v6.8.0. */
+class LaterDeprecatedExtension extends WillBeFinal {}

--- a/tests/Rule/fixtures/FuturePropertyCompatibilityRule/property-assignment.php
+++ b/tests/Rule/fixtures/FuturePropertyCompatibilityRule/property-assignment.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Fixture\FuturePropertyCompatibilityRule;
+
+use Shopware\Core\Framework\Deprecation\BCChange\BecomesReadonly;
+use Shopware\Core\Framework\Deprecation\BCChange\PropertyTypeNarrowing;
+
+class FutureNarrowedProperty
+{
+    #[PropertyTypeNarrowing(version: 'v6.8.0', newType: 'string')]
+    protected ?string $value = null;
+}
+
+class FutureReadonlyProperty
+{
+    #[BecomesReadonly(version: 'v6.8.0')]
+    protected string $value = 'value';
+}
+
+class FuturePropertyConsumer extends FutureNarrowedProperty
+{
+    public function assignNull(): void
+    {
+        $this->value = null;
+    }
+
+    public function assignString(): void
+    {
+        $this->value = 'value';
+    }
+}
+
+class FutureReadonlyPropertyConsumer extends FutureReadonlyProperty
+{
+    public function assignValue(): void
+    {
+        $this->value = 'value';
+    }
+}

--- a/tests/Rule/fixtures/InternalMethodCallRule/app/Test/unknown-class.php
+++ b/tests/Rule/fixtures/InternalMethodCallRule/app/Test/unknown-class.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\App;
+
+/** @var \Grpc\InterceptorChannel $channel */
+$channel = new \stdClass();
+$channel->getTarget();

--- a/tests/Type/FuturePropertyTypeExtensionTest.php
+++ b/tests/Type/FuturePropertyTypeExtensionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+/** @internal */
+class FuturePropertyTypeExtensionTest extends TypeInferenceTestCase
+{
+    public function testAppliesAnnouncedPropertyTypeWidening(): void
+    {
+        foreach (static::gatherAssertTypes(__DIR__ . '/fixtures/FuturePropertyTypeExtension/widens-property.php') as $args) {
+            $assertType = array_shift($args);
+            $file = array_shift($args);
+
+            static::assertIsString($assertType);
+            static::assertIsString($file);
+            $this->assertFileAsserts($assertType, $file, ...$args);
+        }
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/fixtures/FuturePropertyTypeExtension/extension.neon',
+        ];
+    }
+}

--- a/tests/Type/FutureReturnTypeExtensionTest.php
+++ b/tests/Type/FutureReturnTypeExtensionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+/** @internal */
+class FutureReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    public function testAppliesAnnouncedReturnTypeWidening(): void
+    {
+        foreach (static::gatherAssertTypes(__DIR__ . '/fixtures/FutureReturnTypeExtension/widens-return.php') as $args) {
+            $assertType = array_shift($args);
+            $file = array_shift($args);
+
+            static::assertIsString($assertType);
+            static::assertIsString($file);
+            $this->assertFileAsserts($assertType, $file, ...$args);
+        }
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/fixtures/FutureReturnTypeExtension/extension.neon',
+        ];
+    }
+}

--- a/tests/Type/fixtures/FuturePropertyTypeExtension/extension.neon
+++ b/tests/Type/fixtures/FuturePropertyTypeExtension/extension.neon
@@ -1,0 +1,10 @@
+parameters:
+    scanFiles:
+        - widens-property.php
+
+services:
+    -
+        class: Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver
+    -
+        class: Shopware\PhpStan\Type\FuturePropertyTypeExtension
+        tags: [phpstan.broker.expressionTypeResolverExtension]

--- a/tests/Type/fixtures/FuturePropertyTypeExtension/widens-property.php
+++ b/tests/Type/fixtures/FuturePropertyTypeExtension/widens-property.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Fixture\FuturePropertyTypeExtension;
+
+use Shopware\Core\Framework\Deprecation\BCChange\PropertyTypeWidening;
+
+use function PHPStan\Testing\assertType;
+
+class Subject
+{
+    #[PropertyTypeWidening(version: 'v6.8.0', newType: 'string|null')]
+    public string $value = 'value';
+}
+
+$subject = new Subject();
+assertType('string|null', $subject->value);

--- a/tests/Type/fixtures/FutureReturnTypeExtension/extension.neon
+++ b/tests/Type/fixtures/FutureReturnTypeExtension/extension.neon
@@ -1,0 +1,10 @@
+parameters:
+    scanFiles:
+        - widens-return.php
+
+services:
+    -
+        class: Shopware\PhpStan\Rule\FutureCompatibility\AnnouncedTypeResolver
+    -
+        class: Shopware\PhpStan\Type\FutureReturnTypeExtension
+        tags: [phpstan.broker.expressionTypeResolverExtension]

--- a/tests/Type/fixtures/FutureReturnTypeExtension/widens-return.php
+++ b/tests/Type/fixtures/FutureReturnTypeExtension/widens-return.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopware\Core\Framework\Deprecation\BCChange\ReturnTypeWidening;
+
+use function PHPStan\Testing\assertType;
+
+class WidensReturn
+{
+    #[ReturnTypeWidening(version: 'v6.8.0', newType: '?string')]
+    public function getUrl(): string
+    {
+        return 'https://example.com';
+    }
+
+    public function unchanged(): string
+    {
+        return 'stable';
+    }
+}
+
+function (WidensReturn $subject): void {
+    assertType('string|null', $subject->getUrl());
+    assertType('string', $subject->unchanged());
+};

--- a/tests/Type/fixtures/FutureReturnTypeExtension/widens-return.php
+++ b/tests/Type/fixtures/FutureReturnTypeExtension/widens-return.php
@@ -24,3 +24,30 @@ function (WidensReturn $subject): void {
     assertType('string|null', $subject->getUrl());
     assertType('string', $subject->unchanged());
 };
+
+/** @deprecated tag:v6.8.0 - This extension will be removed with the next major version. */
+class DeprecatedCaller
+{
+    public function getUrl(WidensReturn $subject): void
+    {
+        assertType('string', $subject->getUrl());
+    }
+}
+
+class MethodDeprecatedCaller
+{
+    /** @deprecated tag:v6.8.0 - This extension hook will be removed with the next major version. */
+    public function getUrl(WidensReturn $subject): void
+    {
+        assertType('string', $subject->getUrl());
+    }
+}
+
+class LaterDeprecatedCaller
+{
+    /** @deprecated tag:v6.9.0 - This extension hook remains available in v6.8.0. */
+    public function getUrl(WidensReturn $subject): void
+    {
+        assertType('string|null', $subject->getUrl());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a separate opt-in PHPStan configuration for extension code that must work with the current and next Shopware major.

## Details

- keeps the rules out of the package default `rules.neon`
- analyzes Core BC-change attributes without requiring their PHP classes to be present
- documents the explicit include for consumers

## Validation

- `php -d memory_limit=1G vendor/bin/phpunit tests/Rule/FutureCallSiteRuleTest.php`
- `vendor/bin/phpstan analyse src/Rule/FutureCompatibility src/Type/FutureReturnTypeExtension.php --no-progress`